### PR TITLE
Update setup to prevent colons in the working directory for a bot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 **/.DS_Store
 bin/
 vcpkg/
+.idea/

--- a/telegram-bot-api/telegram-bot-api.cpp
+++ b/telegram-bot-api/telegram-bot-api.cpp
@@ -170,6 +170,7 @@ int main(int argc, char *argv[]) {
   parameters->start_time_ = start_time;
   auto net_query_stats = td::create_net_query_stats();
   parameters->net_query_stats_ = net_query_stats;
+  parameters->allow_colon_in_filenames_ = false;
 
   td::OptionParser options;
   bool need_print_usage = false;


### PR DESCRIPTION
When the directory contains a colon, other programming languages treat it like a directory separator making it impossible to access the files